### PR TITLE
TLS Termination Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ def read_file_contents(filepath):
 # Contact Information
 
 ### Maintainer
-- Charles Butler <charles.butler@canonical.com>
+- Charles Butler &lt;[charles.butler@canonical.com](mailto:charles.butler@canonical.com)&gt;
 
 ### Contributors
-- Matthew Bruzek <matthew.bruzek@canonical.com>
+- Mathew Bruzek  &lt;[mathew.bruzek@canonical.com](mailto:mathew.bruzek@canonical.com)&gt;
 
 # Etcd
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ applications backend kv storage, like Docker.
 @when('proxy.available')
 def prepare_etcd_proxy(proxy):
     con_string = proxy.cluster_string()
+    # Save certificates to disk
+    proxy.save_client_credentials('/etc/ssl/etcd')
     opts = {}
     opts['cluster_string'] = con_string
+    opts['client_ca'] = '/etc/ssl/etcd/client-ca.pem'
+    opts['client_cert'] = '/etc/ssl/etcd/client-cert.pem'
+    opts['client_key'] = '/etc/ssl/etcd/client-key.pem'
     render('proxy_systemd_template', '/etc/systemd/system/etcd-proxy.service', opts)
 
 ```

--- a/provides.py
+++ b/provides.py
@@ -29,6 +29,18 @@ class EtcdProvider(RelationBase):
         ''' Set state so the unit can identify it is departing '''
         self.remove_state('{relation_name}.connected')
 
+    def set_client_credentials(self, key, cert, ca):
+        ''' Set the client credentials on the global conversation for this
+        relation. '''
+        self.set_remote('client_key', key)
+        self.set_remote('client_ca', ca)
+        self.set_remote('client_cert', cert)
+
+    def set_cluster_string(self, cluster_string):
+        ''' Set the cluster string on the convsersation '''
+        self.set_remote('cluster_string', cluster_string)
+
+    # Kept for backwords compatibility
     def provide_cluster_string(self, cluster_string):
         '''
         @params cluster_string - fully formed etcd cluster string.
@@ -36,5 +48,4 @@ class EtcdProvider(RelationBase):
         etcd-daemon. Proxy's will need to know each declared member of
         the cluster to effectively proxy.
         '''
-
         self.set_remote('cluster_string', cluster_string)

--- a/requires.py
+++ b/requires.py
@@ -10,28 +10,63 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 
 from charms.reactive import RelationBase
 from charms.reactive import hook
 from charms.reactive import scopes
 
 
-class EtcdClient(RelationBase):
+class EtcdClientProxy(RelationBase):
     scope = scopes.GLOBAL
 
     @hook('{requires:etcd-proxy}-relation-{joined,changed}')
     def changed(self):
         self.set_state('{relation_name}.connected')
-        if self.connection_string():
+        if self.get_connection_string():
             self.set_state('{relation_name}.available')
+            # Get the ca, key, cert from the relation data.
+            cert = self.get_client_credentials()
+            # The tls state depends on the existance of the ca, key and cert.
+            if cert['client_cert'] and cert['client_key'] and cert['client_ca']:  # noqa
+                self.set_state('{relation_name}.tls.available')
 
     @hook('{requires:etcd-proxy}-relation-{broken, departed}')
     def broken(self):
         self.remove_state('{relation_name}.available')
         self.remove_state('{relation_name}.connected')
+        self.remove_state('{relation_name}.tls.available')
+
+    def get_cluster_string(self):
+        ''' Return the connection string, if available, or None. '''
+        return self.get_remote('cluster_string')
+
+    def get_client_credentials(self):
+        ''' Return a dict with the client certificate, ca and key to
+        communicate with etcd using tls. '''
+        return {'client_cert': self.get_remote('client_cert'),
+                'client_key': self.get_remote('client_key'),
+                'client_ca': self.get_remote('client_ca')}
 
     def cluster_string(self):
         """
         Get the cluster string, if available, or None.
         """
-        return self.get_remote('cluster_string')
+        return self.get_cluster_string()
+
+    def save_client_credentials(self, key, cert, ca):
+        ''' Save all the client certificates for etcd to local files. '''
+        self._save_remote_data('client_cert', cert)
+        self._save_remote_data('client_key', key)
+        self._save_remote_data('client_ca', ca)
+
+    def _save_remote_data(self, key, path):
+        ''' Save the remote data to a file indicated by path creating the
+        parent directory if needed.'''
+        value = self.get_remote(key)
+        if value:
+            parent = os.path.dirname(path)
+            if not os.path.isdir(parent):
+                os.makedirs(parent)
+            with open(path, 'w') as stream:
+                stream.write(value)


### PR DESCRIPTION
- Adds methods to set/get the client certificates
- Renamed the provide_client_credentials method to  set_client_credentails (retained old method for backwords compat)
- updates readme with instructions
- Adds method(s) to set bits on disk when interacting with the client certificates
