### PR TITLE
Provide method to set client urls on relation (support etcd gateway)

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -40,6 +40,10 @@ class EtcdProvider(RelationBase):
         ''' Set the cluster string on the convsersation '''
         self.set_remote('cluster', cluster_string)
 
+    def set_client_urls(self, client_urls):
+        ''' Set the client urls on the convsersation '''
+        self.set_remote('client_urls', client_urls)
+
     # Kept for backwords compatibility
     def provide_cluster_string(self, cluster_string):
         '''


### PR DESCRIPTION
This is to support the new etcd gateway,
which replaces the etcd proxy service.

The gateway service requires a list of public client endpoints
to the etcd cluster.

The existing cluster_string is unsuitable,
because that is for the management urls.
